### PR TITLE
Maintenance 2022-12-08 (version 2.0.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Coding standards (phpcs)
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Coding standards (php-cs-fixer)
@@ -50,7 +50,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -92,7 +92,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -120,7 +120,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -129,6 +129,8 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Show psalm version
+        run: psalm --version
       - name: Static analysis (psalm)
         run: psalm --no-progress
 
@@ -148,7 +150,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.6.9" installed="1.6.9" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^4.23.0" installed="4.23.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.26.6" installed="0.26.6" location="./tools/infection" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.9.2" installed="1.9.2" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.1.0" installed="5.1.0" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.26.6" installed="0.26.16" location="./tools/infection" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,11 +23,12 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -40,6 +41,7 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,8 @@
 filter:
+  dependency_paths:
+    - 'vendor/'
   excluded_paths:
     - 'tests/'
-    - 'vendor/'
 
 build:
   dependencies:

--- a/composer.json
+++ b/composer.json
@@ -58,10 +58,10 @@
         ]
     },
     "scripts-descriptions": {
-        "dev:build": "DEV: run dev:fix-style dev:tests and dev:docs, run before pull request",
+        "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit, phpstan, psalm and infection",
+        "dev:test": "DEV: run dev:check-style, phpunit, phpstan, psalm and infection",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:infection": "DEV: run mutation tests using infection"
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,26 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
-## Unreleased 2022-05-27
+## Version 2.0.1
+
+Extract `SoftDaemon::mainloop` read to a protected method `SoftDaemon::continueOnMainLoop()`.
+This change fix the issue detected by `psalm:^5.x`.
+
+Minor changes:
+
+- Upgrade `psalm` version from `4.x` to `5.x`.
+- Update development tools.
+- Update code standard.
+- Remove `@package` annotations.
+- Update GH Workflow:
+  - Replace deprecated `echo ::set-output` instruction.
+  - Add PHP 8.2 to compatibility matrix.
+  - Remove `composer` where it is not required.
+Set up `filter.dependency_paths` setting Scrutinizer-CI.
+
+The following are changes made previously but not released.
+
+### Unreleased 2022-05-27
 
 This is a maintenance update. There are no changes to source code.
 
@@ -19,7 +38,7 @@ This is a maintenance update. There are no changes to source code.
 - Move development tools management from `develop/install-development-tools` to `phive`.
 - Update code style to PSR-12.
 
-## Unreleased 2021-09-26
+### Unreleased 2021-09-26
 
 Development changes:
 

--- a/src/Internal/PcntlSignals.php
+++ b/src/Internal/PcntlSignals.php
@@ -8,6 +8,7 @@ namespace Eclipxe\SoftDaemon\Internal;
  * Wrapper class to pcntl used by SoftDaemon
  * Do not put any logic on this class, it is only used to make system calls
  * @internal
+ * @codeCoverageIgnore
  */
 class PcntlSignals
 {
@@ -32,7 +33,7 @@ class PcntlSignals
      */
     public function block(): bool
     {
-        return pcntl_sigprocmask(SIG_BLOCK, $this->signals); // @codeCoverageIgnore
+        return pcntl_sigprocmask(SIG_BLOCK, $this->signals);
     }
 
     /**
@@ -43,7 +44,7 @@ class PcntlSignals
      */
     public function unblock(): bool
     {
-        return pcntl_sigprocmask(SIG_UNBLOCK, $this->signals); // @codeCoverageIgnore
+        return pcntl_sigprocmask(SIG_UNBLOCK, $this->signals);
     }
 
     /**
@@ -56,6 +57,6 @@ class PcntlSignals
     public function wait(int $seconds): int
     {
         $siginfo = [];
-        return pcntl_sigtimedwait($this->signals, $siginfo, $seconds) ?: 0; // @codeCoverageIgnore
+        return pcntl_sigtimedwait($this->signals, $siginfo, $seconds) ?: 0;
     }
 }

--- a/src/Internal/PcntlSignals.php
+++ b/src/Internal/PcntlSignals.php
@@ -6,9 +6,8 @@ namespace Eclipxe\SoftDaemon\Internal;
 
 /**
  * Wrapper class to pcntl used by SoftDaemon
- * Do not put any logic on this class, it is only osed to make system calls
- * @access private
- * @package SoftDaemon
+ * Do not put any logic on this class, it is only used to make system calls
+ * @internal
  */
 class PcntlSignals
 {
@@ -27,7 +26,7 @@ class PcntlSignals
 
     /**
      * block signals using pcntl_sigprocmask
-     * This is not covered on test because it create a php system call
+     * This is not covered on test because it creates a php system call
      *
      * @return bool
      */
@@ -38,7 +37,7 @@ class PcntlSignals
 
     /**
      * unblock signals using pcntl_sigprocmask
-     * This is not covered on test because it create a php system call
+     * This is not covered on test because it creates a php system call
      *
      * @return bool
      */
@@ -49,7 +48,7 @@ class PcntlSignals
 
     /**
      * wait for blocked signals using pcntl_sigtimedwait
-     * This is not covered on test because it create a php system call
+     * This is not covered on test because it creates a php system call
      *
      * @param int $seconds Numbers of seconds to wait
      * @return int

--- a/src/Sequencers/Exponential.php
+++ b/src/Sequencers/Exponential.php
@@ -8,7 +8,6 @@ use Eclipxe\SoftDaemon\Sequencer;
 
 /**
  * Exponential sequencer calculate = count ^ exp
- * @package SoftDaemon
  */
 class Exponential implements Sequencer
 {

--- a/src/Sequencers/Fixed.php
+++ b/src/Sequencers/Fixed.php
@@ -8,7 +8,6 @@ use Eclipxe\SoftDaemon\Sequencer;
 
 /**
  * Fixed sequencer calculate = fixed value
- * @package SoftDaemon
  */
 class Fixed implements Sequencer
 {

--- a/src/Sequencers/Linear.php
+++ b/src/Sequencers/Linear.php
@@ -8,7 +8,6 @@ use Eclipxe\SoftDaemon\Sequencer;
 
 /**
  * Fixed sequencer calculate = count
- * @package SoftDaemon
  */
 class Linear implements Sequencer
 {

--- a/src/SoftDaemon.php
+++ b/src/SoftDaemon.php
@@ -37,7 +37,7 @@ class SoftDaemon
     protected $pause = false;
 
     /** @var bool flag to control main loop */
-    protected $mainloop = true;
+    protected $mainloop = false;
 
     /** @var PcntlSignals Native php functions (isolated for testing) */
     protected $pcntlsignals;
@@ -120,6 +120,14 @@ class SoftDaemon
     }
 
     /**
+     * Internally check if must continue on main loop
+     */
+    protected function continueOnMainLoop(): bool
+    {
+        return $this->mainloop;
+    }
+
+    /**
      * Count of consecutive times the executable return error
      * This value can only be set to zero using resetErrorCounter
      * @return int
@@ -172,7 +180,7 @@ class SoftDaemon
         // block signals
         $this->pcntlsignals->block();
         // main loop
-        while ($this->mainloop) {
+        while ($this->continueOnMainLoop()) {
             // get the time to wait based on pause or sequencer
             if ($this->getPause()) {
                 $timetowait = $this->waitTime(1);

--- a/src/SoftDaemon.php
+++ b/src/SoftDaemon.php
@@ -7,9 +7,6 @@ namespace Eclipxe\SoftDaemon;
 use Eclipxe\SoftDaemon\Internal\PcntlSignals;
 use Eclipxe\SoftDaemon\Sequencers\Fixed as FixedSequencer;
 
-/**
- * @package SoftDaemon
- */
 class SoftDaemon
 {
     /** maximum wait in seconds (1 hour) */
@@ -139,7 +136,7 @@ class SoftDaemon
 
     /**
      * Set the pause status, if on pause then main loop will only wait 1 second until another signal is received
-     * The executor is not call when the SoftDaemon is on pause
+     * The executor is not called when the SoftDaemon is on pause
      * The time to wait on pause is 1 second, but this is fixed to minwait and maxwait
      *
      * @param bool $pause

--- a/tests/Unit/MockSoftDaemon.php
+++ b/tests/Unit/MockSoftDaemon.php
@@ -57,6 +57,13 @@ class MockSoftDaemon extends SoftDaemon
         parent::terminate();
     }
 
+    protected function continueOnMainLoop(): bool
+    {
+        $continue = parent::continueOnMainLoop();
+        $this->addMessage(sprintf('Check if must continue on main loop (%s)', $continue ? 'yes' : 'no'));
+        return $continue;
+    }
+
     public function exposePcntlSignals(): PcntlSignals
     {
         return $this->pcntlsignals;

--- a/tests/Unit/SoftDaemonTest.php
+++ b/tests/Unit/SoftDaemonTest.php
@@ -144,11 +144,20 @@ class SoftDaemonTest extends TestCase
     public function testRun(): void
     {
         $msg_sd = [
+            'Check if must continue on main loop (yes)',
+            'Check if must continue on main loop (yes)',
+            'Check if must continue on main loop (yes)',
+            'Check if must continue on main loop (yes)',
             'Signal 1 received',
+            'Check if must continue on main loop (yes)',
+            'Check if must continue on main loop (yes)',
             'Signal 10 received',
+            'Check if must continue on main loop (yes)',
             'Signal 12 received',
+            'Check if must continue on main loop (yes)',
             'Signal 15 received',
             'Terminate called',
+            'Check if must continue on main loop (no)',
         ];
         $msg_ex = [
             'Run 1 will return false',


### PR DESCRIPTION
Extract `SoftDaemon::mainloop` read to a protected method `SoftDaemon::continueOnMainLoop()`.
This change fix the issue detected by `psalm:^5.x`.

Minor changes:

- Upgrade `psalm` version from `4.x` to `5.x`.
- Update development tools.
- Update code standard.
- Remove `@package` annotations.
- Update GH Workflow:
  - Replace deprecated `echo ::set-output` instruction.
  - Add PHP 8.2 to compatibility matrix.
  - Remove `composer` where it is not required.
Set up `filter.dependency_paths` setting Scrutinizer-CI.