### PR TITLE
Maintenance 2023-02-07

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,6 @@
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
 /psalm.xml                  export-ignore
+
+# Do not count these files on github code language
+/tests/_files/**            linguist-detectable=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -37,13 +37,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Coding standards (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: true
 
   phpunit:
     name: Tests on PHP ${{ matrix.php-versions }}
@@ -85,7 +87,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -113,7 +115,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, psalm
         env:
@@ -143,7 +145,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: xdebug
           tools: composer:v2, infection
         env:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.13.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.3" installed="3.14.3" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.9.2" installed="1.9.2" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="^5.1.0" installed="5.1.0" location="./tools/psalm" copy="false"/>
-  <phar name="infection" version="^0.26.6" installed="0.26.16" location="./tools/infection" copy="false"/>
+  <phar name="phpstan" version="^1.9.16" installed="1.9.16" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^5.6.0" installed="5.6.0" location="./tools/psalm" copy="false"/>
+  <phar name="infection" version="^0.26.18" installed="0.26.18" location="./tools/infection" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 - 2022 Carlos C Soto
+Copyright (c) 2015 - 2023 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/eclipxe/php-soft-daemon?style=flat-square
 [badge-release]: https://img.shields.io/github/release/eclipxe13/php-soft-daemon?style=flat-square
 [badge-license]: https://img.shields.io/github/license/eclipxe13/php-soft-daemon?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/php-soft-daemon/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/eclipxe13/php-soft-daemon/build.yml?branch=main&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/eclipxe13/php-soft-daemon/main?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/php-soft-daemon/main?style=flat-square
 [badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/php-soft-daemon?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 - Use PHP8.2 on GitHub workflows.
 - Update license year. Happy 2023!
 - Update development tools.
+- Fix build badge on `README.md`.
 
 ## Version 2.0.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 - Refactor test because method `expectWarning()` has been deprecated.
 - Remove `/tests/_files` from GitHub language analysis.
+- Use PHP8.2 on GitHub workflows.
 
 ## Version 2.0.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 ## Maintenance 2023-02-07
 
+- Refactor test because method `expectWarning()` has been deprecated.
+
 ## Version 2.0.1
 
 Extract `SoftDaemon::mainloop` read to a protected method `SoftDaemon::continueOnMainLoop()`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 - Remove `/tests/_files` from GitHub language analysis.
 - Use PHP8.2 on GitHub workflows.
 - Update license year. Happy 2023!
+- Update development tools.
 
 ## Version 2.0.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 
 **Version `0.x.x` doesn't have to apply any of the SemVer rules**
 
+## Maintenance 2023-02-07
+
 ## Version 2.0.1
 
 Extract `SoftDaemon::mainloop` read to a protected method `SoftDaemon::continueOnMainLoop()`.
@@ -25,7 +27,7 @@ Minor changes:
   - Replace deprecated `echo ::set-output` instruction.
   - Add PHP 8.2 to compatibility matrix.
   - Remove `composer` where it is not required.
-Set up `filter.dependency_paths` setting Scrutinizer-CI.
+- Set up `filter.dependency_paths` setting Scrutinizer-CI.
 
 The following are changes made previously but not released.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 ## Maintenance 2023-02-07
 
 - Refactor test because method `expectWarning()` has been deprecated.
+- Remove `/tests/_files` from GitHub language analysis.
 
 ## Version 2.0.1
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ In summary, [SemVer](https://semver.org/) can be viewed as `[ Breaking ].[ Featu
 - Refactor test because method `expectWarning()` has been deprecated.
 - Remove `/tests/_files` from GitHub language analysis.
 - Use PHP8.2 on GitHub workflows.
+- Update license year. Happy 2023!
 
 ## Version 2.0.1
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>src</file>
     <file>tests</file>

--- a/tests/Unit/SoftDaemonTest.php
+++ b/tests/Unit/SoftDaemonTest.php
@@ -141,8 +141,8 @@ class SoftDaemonTest extends TestCase
         @$sd->exposeSignalHandler(-128);
         $error = error_get_last();
 
-        $this->assertSame(E_USER_WARNING, $error['type']);
-        $this->assertSame('Eclipxe\SoftDaemon\SoftDaemon::signalHandler(-128) do nothing', $error['message']);
+        $this->assertSame(E_USER_WARNING, intval($error['type'] ?? 0));
+        $this->assertSame('Eclipxe\SoftDaemon\SoftDaemon::signalHandler(-128) do nothing', strval($error['message'] ?? ''));
     }
 
     public function testRun(): void

--- a/tests/Unit/SoftDaemonTest.php
+++ b/tests/Unit/SoftDaemonTest.php
@@ -136,9 +136,13 @@ class SoftDaemonTest extends TestCase
     public function testSignalHandlerBadSignal(): void
     {
         $sd = new MockSoftDaemon($this->createMockExecutable());
-        $this->expectWarning();
-        $this->expectWarningMessage('Eclipxe\SoftDaemon\SoftDaemon::signalHandler(-128) do nothing');
-        $sd->exposeSignalHandler(-128);
+
+        error_clear_last();
+        @$sd->exposeSignalHandler(-128);
+        $error = error_get_last();
+
+        $this->assertSame(E_USER_WARNING, $error['type']);
+        $this->assertSame('Eclipxe\SoftDaemon\SoftDaemon::signalHandler(-128) do nothing', $error['message']);
     }
 
     public function testRun(): void


### PR DESCRIPTION
Fix GH build workflow.

- Refactor test because method `expectWarning()` has been deprecated.
- Remove `/tests/_files` from GitHub language analysis.
- Use PHP8.2 on GitHub workflows.
- Update license year. Happy 2023!
- Update development tools.
- Fix build badge on `README.md`.
